### PR TITLE
Expand UTM presets for social sharing

### DIFF
--- a/app/lib/utm.mjs
+++ b/app/lib/utm.mjs
@@ -1,0 +1,45 @@
+export const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
+
+export function buildUtmUrl(baseUrl, params = {}) {
+  if (!baseUrl) return '';
+
+  const [urlWithoutHash, hash] = baseUrl.split('#');
+  const [base, query = ''] = urlWithoutHash.split('?');
+  const searchParams = new URLSearchParams(query);
+
+  UTM_KEYS.forEach((key) => {
+    if (params[key]) {
+      searchParams.set(key, params[key]);
+    } else {
+      searchParams.delete(key);
+    }
+  });
+
+  const queryString = searchParams.toString();
+  const rebuilt = queryString ? `${base}?${queryString}` : base;
+
+  return hash ? `${rebuilt}#${hash}` : rebuilt;
+}
+
+export function extractUtmParams(inputUrl) {
+  if (!inputUrl) {
+    return { baseUrl: '', utmParams: {} };
+  }
+
+  const [urlWithoutHash, hash] = inputUrl.split('#');
+  const [base, query = ''] = urlWithoutHash.split('?');
+  const searchParams = new URLSearchParams(query);
+  const utmParams = {};
+
+  UTM_KEYS.forEach((key) => {
+    if (searchParams.has(key)) {
+      utmParams[key] = searchParams.get(key) ?? '';
+      searchParams.delete(key);
+    }
+  });
+
+  const queryString = searchParams.toString();
+  const rebuilt = queryString ? `${base}?${queryString}` : base;
+
+  return { baseUrl: hash ? `${rebuilt}#${hash}` : rebuilt, utmParams };
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { QRCodeCanvas } from 'qrcode.react';
 
@@ -105,6 +106,12 @@ export default function HomePage() {
       >
         🌸 BloomShort 🌸
       </motion.h1>
+      <Link
+        href="/utm"
+        className="mb-6 text-purple-700 underline font-semibold hover:text-purple-900 transition"
+      >
+        Build a UTM tracking URL →
+      </Link>
 
       <motion.form
         onSubmit={handleSubmit}

--- a/app/utm/page.js
+++ b/app/utm/page.js
@@ -1,0 +1,282 @@
+'use client';
+
+import { useMemo, useState, useEffect } from 'react';
+import Link from 'next/link';
+import { buildUtmUrl, extractUtmParams } from '../lib/utm.mjs';
+
+const PRESETS = [
+  {
+    id: 'facebook-post',
+    label: 'Facebook Post',
+    values: { utm_source: 'facebook', utm_medium: 'social', utm_campaign: 'post' },
+  },
+  {
+    id: 'facebook-comment',
+    label: 'Facebook Comment',
+    values: { utm_source: 'facebook', utm_medium: 'social', utm_campaign: 'comment' },
+  },
+  {
+    id: 'facebook-ads',
+    label: 'Facebook Ads',
+    values: { utm_source: 'facebook', utm_medium: 'paid_social', utm_campaign: 'facebook_ads' },
+  },
+  {
+    id: 'facebook-messenger',
+    label: 'Facebook Messenger',
+    values: { utm_source: 'facebook', utm_medium: 'messenger', utm_campaign: 'dm' },
+  },
+  {
+    id: 'instagram-story',
+    label: 'Instagram Story',
+    values: { utm_source: 'instagram', utm_medium: 'social', utm_campaign: 'story' },
+  },
+  {
+    id: 'instagram-reel',
+    label: 'Instagram Reel',
+    values: { utm_source: 'instagram', utm_medium: 'social', utm_campaign: 'reel' },
+  },
+  {
+    id: 'instagram-dm',
+    label: 'Instagram DM',
+    values: { utm_source: 'instagram', utm_medium: 'messenger', utm_campaign: 'dm' },
+  },
+  {
+    id: 'x-post',
+    label: 'X (Twitter) Post',
+    values: { utm_source: 'x', utm_medium: 'social', utm_campaign: 'post' },
+  },
+  {
+    id: 'x-reply',
+    label: 'X (Twitter) Reply',
+    values: { utm_source: 'x', utm_medium: 'social', utm_campaign: 'reply' },
+  },
+  {
+    id: 'x-dm',
+    label: 'X (Twitter) DM',
+    values: { utm_source: 'x', utm_medium: 'messenger', utm_campaign: 'dm' },
+  },
+  {
+    id: 'linkedin-sponsored',
+    label: 'LinkedIn Sponsored',
+    values: { utm_source: 'linkedin', utm_medium: 'paid_social', utm_campaign: 'sponsored' },
+  },
+  {
+    id: 'linkedin-post',
+    label: 'LinkedIn Post',
+    values: { utm_source: 'linkedin', utm_medium: 'social', utm_campaign: 'post' },
+  },
+  {
+    id: 'linkedin-comment',
+    label: 'LinkedIn Comment',
+    values: { utm_source: 'linkedin', utm_medium: 'social', utm_campaign: 'comment' },
+  },
+  {
+    id: 'linkedin-message',
+    label: 'LinkedIn Message',
+    values: { utm_source: 'linkedin', utm_medium: 'messenger', utm_campaign: 'dm' },
+  },
+  {
+    id: 'tiktok-video',
+    label: 'TikTok Video',
+    values: { utm_source: 'tiktok', utm_medium: 'social', utm_campaign: 'video' },
+  },
+  {
+    id: 'tiktok-comment',
+    label: 'TikTok Comment',
+    values: { utm_source: 'tiktok', utm_medium: 'social', utm_campaign: 'comment' },
+  },
+  {
+    id: 'tiktok-dm',
+    label: 'TikTok DM',
+    values: { utm_source: 'tiktok', utm_medium: 'messenger', utm_campaign: 'dm' },
+  },
+  {
+    id: 'youtube-description',
+    label: 'YouTube Description',
+    values: { utm_source: 'youtube', utm_medium: 'video', utm_campaign: 'description' },
+  },
+  {
+    id: 'youtube-comment',
+    label: 'YouTube Comment',
+    values: { utm_source: 'youtube', utm_medium: 'social', utm_campaign: 'comment' },
+  },
+  {
+    id: 'youtube-community',
+    label: 'YouTube Community Post',
+    values: { utm_source: 'youtube', utm_medium: 'social', utm_campaign: 'community_post' },
+  },
+];
+
+export default function UtmBuilderPage() {
+  const [url, setUrl] = useState('');
+  const [utmSource, setUtmSource] = useState('');
+  const [utmMedium, setUtmMedium] = useState('');
+  const [utmCampaign, setUtmCampaign] = useState('');
+  const [utmTerm, setUtmTerm] = useState('');
+  const [utmContent, setUtmContent] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!url || !url.includes('utm_')) return;
+    const { baseUrl, utmParams } = extractUtmParams(url);
+    if (Object.keys(utmParams).length === 0) return;
+    setUrl(baseUrl);
+    setUtmSource(utmParams.utm_source ?? '');
+    setUtmMedium(utmParams.utm_medium ?? '');
+    setUtmCampaign(utmParams.utm_campaign ?? '');
+    setUtmTerm(utmParams.utm_term ?? '');
+    setUtmContent(utmParams.utm_content ?? '');
+  }, [url]);
+
+  const utmUrl = useMemo(
+    () =>
+      buildUtmUrl(url, {
+        utm_source: utmSource,
+        utm_medium: utmMedium,
+        utm_campaign: utmCampaign,
+        utm_term: utmTerm,
+        utm_content: utmContent,
+      }),
+    [url, utmSource, utmMedium, utmCampaign, utmTerm, utmContent]
+  );
+
+  const handleCopy = async () => {
+    if (!utmUrl) return;
+    await navigator.clipboard.writeText(utmUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const applyPreset = (preset) => {
+    setUtmSource(preset.values.utm_source);
+    setUtmMedium(preset.values.utm_medium);
+    setUtmCampaign(preset.values.utm_campaign);
+  };
+
+  const resetFields = () => {
+    setUtmSource('');
+    setUtmMedium('');
+    setUtmCampaign('');
+    setUtmTerm('');
+    setUtmContent('');
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-r from-blue-100 via-purple-200 to-pink-200 p-8 font-sans">
+      <div className="w-full max-w-3xl space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-4xl font-bold text-purple-700">UTM Builder</h1>
+          <Link href="/" className="text-purple-700 underline">
+            Back to BloomShort
+          </Link>
+        </div>
+
+        <p className="text-purple-700">
+          Paste a URL, add UTM parameters, and copy the tracking-ready link.
+        </p>
+
+        <div className="space-y-4">
+          <input
+            type="url"
+            placeholder="https://example.com/landing-page"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className="w-full p-4 rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-purple-300 text-purple-900 font-medium"
+          />
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <input
+              type="text"
+              placeholder="utm_source"
+              value={utmSource}
+              onChange={(e) => setUtmSource(e.target.value)}
+              className="p-3 rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-purple-300 text-purple-900 font-medium"
+            />
+            <input
+              type="text"
+              placeholder="utm_medium"
+              value={utmMedium}
+              onChange={(e) => setUtmMedium(e.target.value)}
+              className="p-3 rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-purple-300 text-purple-900 font-medium"
+            />
+            <input
+              type="text"
+              placeholder="utm_campaign"
+              value={utmCampaign}
+              onChange={(e) => setUtmCampaign(e.target.value)}
+              className="p-3 rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-purple-300 text-purple-900 font-medium"
+            />
+            <input
+              type="text"
+              placeholder="utm_term"
+              value={utmTerm}
+              onChange={(e) => setUtmTerm(e.target.value)}
+              className="p-3 rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-purple-300 text-purple-900 font-medium"
+            />
+            <input
+              type="text"
+              placeholder="utm_content"
+              value={utmContent}
+              onChange={(e) => setUtmContent(e.target.value)}
+              className="p-3 rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-purple-300 text-purple-900 font-medium"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold text-purple-700">Quick presets</h2>
+          <div className="flex flex-wrap gap-2">
+            {PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => applyPreset(preset)}
+                className="px-4 py-2 rounded-full bg-purple-200 text-purple-800 font-semibold shadow-sm hover:bg-purple-300 transition"
+              >
+                {preset.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={resetFields}
+              className="px-4 py-2 rounded-full bg-gray-200 text-gray-700 font-semibold shadow-sm hover:bg-gray-300 transition"
+            >
+              Reset UTMs
+            </button>
+          </div>
+        </div>
+
+        <div className="bg-white/80 rounded-xl p-6 shadow-lg space-y-4">
+          <h2 className="text-lg font-semibold text-purple-700">Your tracking URL</h2>
+          <input
+            type="text"
+            value={utmUrl}
+            readOnly
+            placeholder="Your UTM URL will appear here"
+            className="w-full p-3 rounded-lg border border-purple-200 bg-white text-purple-900 font-medium"
+          />
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition"
+            >
+              Copy URL
+            </button>
+            {utmUrl && (
+              <a
+                href={utmUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition"
+              >
+                Open URL
+              </a>
+            )}
+          </div>
+          {copied && <p className="text-green-600 font-semibold">✅ Copied to clipboard!</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.75.0",

--- a/tests/utm.test.mjs
+++ b/tests/utm.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildUtmUrl, extractUtmParams } from '../app/lib/utm.mjs';
+
+test('buildUtmUrl appends UTM params and preserves hashes', () => {
+  const url = 'https://example.com/landing#section';
+  const result = buildUtmUrl(url, {
+    utm_source: 'facebook',
+    utm_medium: 'paid_social',
+    utm_campaign: 'launch',
+  });
+
+  assert.equal(
+    result,
+    'https://example.com/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=launch#section'
+  );
+});
+
+test('buildUtmUrl removes empty UTM values and keeps existing query params', () => {
+  const url = 'https://example.com/page?ref=newsletter';
+  const result = buildUtmUrl(url, {
+    utm_source: 'newsletter',
+    utm_medium: '',
+  });
+
+  assert.equal(result, 'https://example.com/page?ref=newsletter&utm_source=newsletter');
+});
+
+test('extractUtmParams returns base url and detected utm values', () => {
+  const url =
+    'https://example.com/page?utm_source=linkedin&utm_medium=social&ref=sidebar#top';
+  const { baseUrl, utmParams } = extractUtmParams(url);
+
+  assert.equal(baseUrl, 'https://example.com/page?ref=sidebar#top');
+  assert.deepEqual(utmParams, { utm_source: 'linkedin', utm_medium: 'social' });
+});
+
+test('buildUtmUrl overwrites existing utm values while keeping other query params', () => {
+  const url =
+    'https://example.com/page?utm_source=old&utm_campaign=spring&ref=sidebar&utm_medium=social';
+  const result = buildUtmUrl(url, {
+    utm_source: 'facebook',
+    utm_medium: 'paid_social',
+    utm_campaign: 'launch',
+  });
+
+  assert.equal(
+    result,
+    'https://example.com/page?utm_source=facebook&utm_campaign=launch&ref=sidebar&utm_medium=paid_social'
+  );
+});


### PR DESCRIPTION
### Motivation
- Provide more realistic, sharable UTM presets for common social placements (posts, comments, DMs, community posts) so users can quickly generate tracking links tailored to where they share them. 
- Ensure the UTM utilities keep other query params intact and reliably overwrite existing UTM values when building new tracking links.

### Description
- Expanded the `PRESETS` list in `app/utm/page.js` to include additional placements for Facebook (post, comment, messenger), Instagram (reel, DM), X (reply, DM), LinkedIn (post, comment, message), TikTok (comment, DM), and YouTube (comment, community post). 
- Added a test in `tests/utm.test.mjs` to verify `buildUtmUrl` overwrites existing UTM values while preserving other query parameters and adjusted the expected output to match `URLSearchParams` ordering. 
- Committed changes to `app/utm/page.js` and `tests/utm.test.mjs` under the PR title `Expand UTM presets for social sharing`.

### Testing
- Ran `npm test` which executed the node tests and they all passed (`4/4` tests passing). 
- Ran `npm run lint` which completed with no reported lint errors. 
- Rendered `/utm` via a Playwright smoke-check to capture an updated screenshot of the UTM builder which completed successfully.